### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,7 @@
   "bugs": {
     "url": "https://github.com/fengyuanchen/completer/issues"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/fengyuanchen/completer/blob/master/LICENSE.md"
-  },
+  "license": "MIT",
   "dependencies": {
     "jquery": ">= 1.9.0"
   },


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)